### PR TITLE
Fix for DIActorProducer #941

### DIFF
--- a/src/contrib/dependencyInjection/Akka.DI.Core/DIActorProducer.cs
+++ b/src/contrib/dependencyInjection/Akka.DI.Core/DIActorProducer.cs
@@ -35,7 +35,7 @@ namespace Akka.DI.Core
         /// </summary>
         public Type ActorType
         {
-            get { return this.dependencyResolver.GetType(); }
+            get { return this.actorType.GetType(); }
         }
         /// <summary>
         /// Creates an instance of the Actor based on the Type specified in the constructor parameter actorName


### PR DESCRIPTION
Now returns the proper ActorType instead of the Type of the
depencyResolver.